### PR TITLE
Fixed regex for sed to allow white spaces in names

### DIFF
--- a/tools/spolpred/spolpred.sh
+++ b/tools/spolpred/spolpred.sh
@@ -5,6 +5,6 @@ shift
 
 spolpred $@
 
-sed -i s/^.*\t/$name/ output.txt
+sed -i "s/^[^\t]*/$name/" output.txt
 
 exit 0


### PR DESCRIPTION
Thanks to @ericenns for the regex wizardry. I tested this with and without spaces and it works as intended now

Sample output:
![spolpred1](https://cloud.githubusercontent.com/assets/14098761/11901000/cc38896c-a56e-11e5-80a6-358b9d338411.png)
![spolpred2](https://cloud.githubusercontent.com/assets/14098761/11901002/ce9b5f54-a56e-11e5-9b26-8fdad22b606d.png)
(don't mind the 0s, I ran the first one with reverse)