### PR TITLE
Made mrbayes return 1 on error instead of 0

### DIFF
--- a/tools/mrbayes/mrbayes.xml
+++ b/tools/mrbayes/mrbayes.xml
@@ -20,7 +20,7 @@
         begin mrbayes;
         set Seed=$seed;
         set Swapseed=$swapseed;
-        set quitonerror=no;
+        set quitonerror=yes;
         execute $data;
         outgroup $outgroup;
         $model;


### PR DESCRIPTION
It was actually returning 0, even when error was encountered. So I set the quitonerror flag to 'yes' instead of 'no'. Seems to have fixed the issue
