### PR TITLE
Adding Python Dependencies to SRST2

### DIFF
--- a/packages/package_srst2_0_1_4_6/tool_dependencies.xml
+++ b/packages/package_srst2_0_1_4_6/tool_dependencies.xml
@@ -13,7 +13,7 @@
 	    <install version="1.0">
 	         <actions_group>
 	            <actions>
-	                <action type="download_by_url">https://github.com/katholt/srst2/archive/v0.1.6.tar.gz</action>
+	                <action type="download_by_url" sha256sum="24cbd03933d4cc14bbfa7f8a073c9b0caafb13d55afb3bfa25f8b093fc5bc615">https://github.com/katholt/srst2/archive/v0.1.6.tar.gz</action>
 					<action type="shell_command">cp ./scripts/getmlst.py $INSTALL_DIR</action>
 					<action type="shell_command">cp ./scripts/srst2.py $INSTALL_DIR</action>
                     <action type="chmod"><file mode="777">$INSTALL_DIR/getmlst.py</file></action>

--- a/packages/package_srst2_0_1_4_6/tool_dependencies.xml
+++ b/packages/package_srst2_0_1_4_6/tool_dependencies.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0"?>
 <tool_dependency>
+	<package name="python" version="2.7.10">
+		<repository name="package_python_2_7_10" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="numpy" version="1.9">
+		<repository name="package_python_2_7_numpy_1_9" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="scipy" version="0.14">
+		<repository name="package_python_2_7_scipy_0_14" owner="iuc" prior_installation_required="True" />
+    </package>
     <package name="srst2" version="0.1.4.6">
 	    <install version="1.0">
 	         <actions_group>
@@ -9,13 +18,31 @@
 					<action type="shell_command">cp ./scripts/srst2.py $INSTALL_DIR</action>
                     <action type="chmod"><file mode="777">$INSTALL_DIR/getmlst.py</file></action>
 					<action type="chmod"><file mode="777">$INSTALL_DIR/srst2.py</file></action>
+					<action type="set_environment_for_install">
+                        <repository name="package_python_2_7_10" owner="iuc">
+                    		<package name="python" version="2.7.10" />
+            			</repository>
+						<repository name="package_python_2_7_numpy_1_9" owner="iuc">
+		                    <package name="numpy" version="1.9" />
+		                </repository>
+		                <repository name="package_python_2_7_scipy_0_14" owner="iuc">
+		                    <package name="scipy" version="0.14" />
+		                </repository>
+
+                 	</action>
                     <action type="set_environment">
+                    	<environment_variable action="append_to" name="PYTHONPATH">$INSTALL_DIR/lib/python</environment_variable>
+ 		                <environment_variable action="append_to" name="PYTHONPATH">$INSTALL_DIR</environment_variable>
+		                <environment_variable action="append_to" name="PYTHONPATH">$ENV[PYTHONPATH_NUMPY]</environment_variable>
+		                <environment_variable action="append_to" name="PYTHONPATH">$ENV[PYTHONPATH_NUMPY]/lib/python</environment_variable>
+		                <environment_variable action="append_to" name="PYTHONPATH">$ENV[PYTHONPATH_SCIPY]</environment_variable>
+		                <environment_variable action="append_to" name="PYTHONPATH">$ENV[PYTHONPATH_SCIPY]/lib/python</environment_variable>
 	                    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR</environment_variable>
+	                    <environment_variable name="PATH" action="prepend_to">$ENV[PYTHONHOME]/bin</environment_variable>
 	                    <environment_variable name="BASE" action="set_to">$INSTALL_DIR</environment_variable>
                     </action>
 	            </actions>
 	       	</actions_group>
 	    </install>
 	</package>
-
 </tool_dependency>

--- a/tools/srst2/tool_dependencies.xml
+++ b/tools/srst2/tool_dependencies.xml
@@ -21,8 +21,9 @@
             </actions_group>
         </install>
     </package>
-    <package name="srst2" version="0.1.4.5">
-    	<repository name="package_srst2_0_1_4_5" owner="nml" />
+    
+    <package name="srst2" version="0.1.4.6">
+    	<repository name="package_srst2_0_1_4_6" owner="nml" />
     </package>
 	<package name="samtools" version="0.1.18">
 		<repository name="package_samtools_0_1_18" owner="iuc" />


### PR DESCRIPTION
Added Python 2.7.10, Numpy 1.9 and Scipy 0.14. 

Tested this install on a Docker container of bgruening Galaxy Docker. Installs and runs. 