### PR TITLE
Adding Atlas Requirement

### DIFF
--- a/packages/package_srst2_0_1_4_6/tool_dependencies.xml
+++ b/packages/package_srst2_0_1_4_6/tool_dependencies.xml
@@ -3,6 +3,9 @@
 	<package name="python" version="2.7.10">
 		<repository name="package_python_2_7_10" owner="iuc" prior_installation_required="True" />
     </package>
+    <package name="atlas" version="3.10.2">
+    	<repository name="package_atlas_3_10" owner="iuc" prior_installation_required="True" />
+    </package>
     <package name="numpy" version="1.9">
 		<repository name="package_python_2_7_numpy_1_9" owner="iuc" prior_installation_required="True" />
     </package>
@@ -22,6 +25,9 @@
                         <repository name="package_python_2_7_10" owner="iuc">
                     		<package name="python" version="2.7.10" />
             			</repository>
+            			<repository name="package_atlas_3_10" owner="iuc">
+		                    <package name="atlas" version="3.10.2" />
+		                </repository>
 						<repository name="package_python_2_7_numpy_1_9" owner="iuc">
 		                    <package name="numpy" version="1.9" />
 		                </repository>
@@ -40,6 +46,7 @@
 	                    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR</environment_variable>
 	                    <environment_variable name="PATH" action="prepend_to">$ENV[PYTHONHOME]/bin</environment_variable>
 	                    <environment_variable name="BASE" action="set_to">$INSTALL_DIR</environment_variable>
+	                    <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$ENV[ATLAS_LIB_DIR]</environment_variable>
                     </action>
 	            </actions>
 	       	</actions_group>


### PR DESCRIPTION
Numpy requires atlas to run. Was missed in initial testing as environments tested had Numpy already installed. @Takadonet @ericenns  