### PR TITLE
Updating combine_json's Input Capabilities

### DIFF
--- a/tools/combineJSON/combineJSON.py
+++ b/tools/combineJSON/combineJSON.py
@@ -22,7 +22,7 @@ args = parser.parse_args()
 input_files = args.i
 json_file = []
 
-if input_files is None or len(input_files) < 2:
+if input_files is None or len(input_files) < 1:
     print('Not enough input files. '
           'Please use -i filename.txt filename1.txt '
           'to combine JSON data files')


### PR DESCRIPTION
combine_json should be allowed to take in one input, and simply pass through the same result as the output. This is required within the bio_hansel workflow, for the single file case.