### PR TITLE
Updating bio_hansel to 1.3.1

### DIFF
--- a/tools/hansel/bio_hansel.xml
+++ b/tools/hansel/bio_hansel.xml
@@ -1,7 +1,7 @@
-<tool id="bio_hansel" name="Bio Hansel" version="1.3.0">
+<tool id="bio_hansel" name="Bio Hansel" version="1.3.1">
     <description>SNV Subtyping with genome assemblies or reads</description>
     <requirements>
-        <requirement type="package" version="1.3.0">bio_hansel</requirement>
+        <requirement type="package" version="1.3.1">bio_hansel</requirement>
         <requirement type="package" version="17.2.0">attrs</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
@@ -323,7 +323,7 @@ Galaxy wrapper written by Matthew Gopez at the Public Health Agency of Canada, N
     <citations>
         <citation type="bibtex">@ARTICLE{a1,
             title = {A robust genotyping scheme for *Salmonella enterica* serovar Heidelberg clones circulating in North America.},
-            author = {Geneviève Labbé, James Robertson, Peter Kruczkiewicz, Marisa Rankin, Matthew Gopez, Chad R. Laing, Philip Mabon, Kim Ziebell, Aleisha R. Reimer, Lorelee Tschetter, Gary Van Domselaar, Sadjia Bekal, Kimberley A. MacDonald, Linda Hoang, Linda Chui, Danielle Daignault, Durda Slavic, Frank Pollari, E. Jane Parmley, Philip Mabon, Elissa Giang, Lok Kan Lee, Jonathan Moffat, Marisa Rankin, Joanne MacKinnon, Roger Johnson, John H.E. Nash.},
+            author = {Geneviève Labbé, James Robertson, Peter Kruczkiewicz, Marisa Rankin, Matthew Gopez, Chad R. Laing, Philip Mabon, Kim Ziebell, Aleisha R. Reimer, Lorelee Tschetter, Gary Van Domselaar, Sadjia Bekal, Kimberley A. MacDonald, Linda Hoang, Linda Chui, Danielle Daignault, Durda Slavic, Frank Pollari, E. Jane Parmley, Elissa Giang, Lok Kan Lee, Jonathan Moffat, Joanne MacKinnon, Roger Johnson, John H.E. Nash.},
             url = {https://github.com/phac-nml/bio_hansel}
             }
         }</citation>


### PR DESCRIPTION
- Updated bio_hansel to 1.3.1, which uses the updated Enteritidis scheme
- Fixed citation duplication