### PR TITLE
Fixed spaces in name

### DIFF
--- a/tools/staramr/staramr_search.xml
+++ b/tools/staramr/staramr_search.xml
@@ -4,9 +4,11 @@
         <requirement type="package" version="0.2.0">staramr</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
+        #import re
+
         #set $named_genomes = ''
         #for $genome in $genomes
-            #set $_named_genome = '"{}.fasta"'.format($genome.element_identifier)
+            #set $_named_genome = re.sub(r'(\s|\(|\))', '_', '"{}.fasta"'.format($genome.element_identifier))
             ln -s "$genome" $_named_genome &&
             #set $named_genomes = $named_genomes + ' ' + $_named_genome
         #end for
@@ -108,6 +110,12 @@
             <param name="pid_threshold" value="99.8" />
 
             <output name="summary" file="test3-summary.tsv" ftype="tabular" />
+        </test>
+        <test>
+            <param name="genomes" value="16S rc_gyrA rc_beta-lactam spaces (extra:characters).fsa" />
+            <param name="pid_threshold" value="99.8" />
+
+            <output name="summary" file="test4-summary.tsv" ftype="tabular" />
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/staramr/test-data/16S rc_gyrA rc_beta-lactam spaces (extra:characters).fsa
+++ b/tools/staramr/test-data/16S rc_gyrA rc_beta-lactam spaces (extra:characters).fsa
@@ -1,0 +1,1 @@
+16S-rc_gyrA-rc_beta-lactam.fsa

--- a/tools/staramr/test-data/test4-summary.tsv
+++ b/tools/staramr/test-data/test4-summary.tsv
@@ -1,0 +1,2 @@
+Isolate ID	Genotype	Predicted Phenotype
+16S_rc_gyrA_rc_beta-lactam_spaces__extra:characters_.fsa	None	Sensitive


### PR DESCRIPTION
This fixes an issue where there were spaces (or other characters) in the Galaxy tool dataset name, see https://github.com/phac-nml/staramr/issues/18.  In this case, the dataset name was **Shovill on data 11 and data 10: Contigs.fasta**, but this caused issues when running staramar (in `makeblastdb`).

My solution for Galaxy is to swap out spaces and () characters with an underscore _.

I did not increment the Galaxy tool version number since this is just a small bugfix (when submitting to the Galaxy toolshed, this version will now labelled version `0.2.0`, though the older version of the tool will still be kept around if needed).