### PR TITLE
Fix bug when running collection

### DIFF
--- a/tools/mykrobe_parser/mykrobe_parser.xml
+++ b/tools/mykrobe_parser/mykrobe_parser.xml
@@ -1,4 +1,4 @@
-<tool id="mykrobe_parseR" name="mykrobe_parseR" version="0.1.0">
+<tool id="mykrobe_parseR" name="mykrobe_parseR" version="0.1.1">
     <requirements>
         <requirement type="package" version="3.4.1">r-base</requirement>
         <requirement type="package" version="1.5.0">r-jsonlite</requirement>
@@ -14,7 +14,7 @@
         #if $input.type == 'collection'
             mkdir collection_files &&
             #for $file in $input.collection
-                cp "$file" collection_files/"$file.name".json &&
+                ln -s "$file" collection_files/"$file.element_identifier".json &&
             #end for
         #end if
 


### PR DESCRIPTION
now getting the element_identifier and not the filename itself. Was causing issues where same file name was being overwritten all the time. Switch to soft link instead of cp.