### PR TITLE
Add fastq_dump colon regex

### DIFF
--- a/tools/biohansel/biohansel.xml
+++ b/tools/biohansel/biohansel.xml
@@ -10,6 +10,7 @@
 
 ## Illumina FASTQ naming regular expression (https://github.com/phac-nml/biohansel/issues/38)
 #set global $ILLUMINA_REGEX = $re.compile(r'^([\w\-\_]+)_S\d+_L\d{3}_R(\d)_001\.fastq(\.gz)?$')
+#set global $FASTQ_DUMP_REGEX = $re.compile(r'^(\w+|\d+):((forward|reverse)(_\d+)?)\.fastq(\.gz|sanger)?$')
 
 #def is_gzipped_fastq($data_input)
   ## Is FASTQ data param gzipped type? i.e. either 'fastq.gz' or 'fastqsanger.gz'?
@@ -24,13 +25,17 @@
 #def base_sample_name($name)
   ## Get the base sample name and append 1/2 depending on if forward/reverse read
   #set $illumina_match = $ILLUMINA_REGEX.match($name)
+  #set $fastq_dump_match = $FASTQ_DUMP_REGEX.match($name)
+
   #if $illumina_match
     #return $illumina_match.group(1)
   #elif $re.search(r'_R(1|2)', $name):
     #return $re.sub(r'(.+)_R(1|2)([^\.]*)(\..+)', r'\1\3', $name)
   #elif $re.match(r'.+_\d\.', $name):
     #return $re.sub(r'(.+)_(\d)(\..+)', r'\1', $name)
-  #else
+  #elif $fastq_dump_match
+      #return $fastq_dump_match.group(1)
+  #else    
     #return $name
   #end if
 #end def


### PR DESCRIPTION
This is a fix for fastq dump files, that have a colon in the name.
In the output names like `SRR190010:forward` will be fixed to show only `SRR190010`.