### PR TITLE
MASH distance feature implementation for ectyper v0.8.1

### DIFF
--- a/tools/ectyper/ectyper.xml
+++ b/tools/ectyper/ectyper.xml
@@ -19,6 +19,10 @@
     ln -s "${input}" "${input.name}" &&
     #set $genomes = $input.name
   #end if
+
+  #if $mash_input
+    ln -s "${mash_input}" mash_sketch.msh &&
+  #end if
  
   ectyper  --cores \${GALAXY_SLOTS:-4} 
   --input "${genomes}" 
@@ -27,6 +31,9 @@
   #if $adv_param.verifyEcoli
     --verify
   #end if
+  #if $mash_input
+    --refseq mash_sketch.msh
+  #end if   
   #if $adv_param.alleleSequence
     --sequence
   #end if
@@ -34,7 +41,8 @@
   ]]>
   </command>
   <inputs>
-    <param name="input" type="data"  format="fastq,fasta" label="Input(s)" help="FASTA or FASTQ file(s) with contig(s)"/>
+    <param name="input" type="data"  format="fastq,fasta" label="Genome(s) input(s)" help="FASTA or FASTQ file(s) with contig(s)"/>
+    <param name="mash_input" type="data" optional="true" format="binary" label="Mash genome sketches (Optional)" help="Optionally provide MASH sketches to find closest genome (in case O/H typing fails)"/>
     <section name="adv_param" title="Advanced parameters" expanded="False">
       <param name="min_percentIdentity" type="integer" value="90" min="1" max="100"/>
       <param name="percentLength" type="integer" value="50" min="1" max="100"/>
@@ -44,7 +52,7 @@
     </section>  
   </inputs>
   <outputs>
-    <data name="output_result" format="tabular" header="true" from_work_dir="output.tsv" label="${tool.name} serotype report"> </data> 
+    <data name="output_result" format="tabular" from_work_dir="output.tsv" label="${tool.name} serotype report"> </data> 
     <data name="output_log" format="text" from_work_dir="ectyper.log" label="${tool.name} log file"> 
         <filter>adv_param['logging']==True</filter>
     </data>   
@@ -56,7 +64,7 @@
             <has_text text="O22"/> 
             <has_text text="H8"/> 
       </assert_stderr>
-      <output name="output.tsv" ftype="tabular" >
+      <output name="output_result" ftype="tabular" >
           <assert_contents>
               <has_text_matching expression="O22"/>
          </assert_contents>
@@ -67,7 +75,7 @@
   <help>
 **Syntax**
 
-This tool identifies the serotype of Escherichia coli genome sequences based on a set of *wzm/wzy*, *wzx/wzy* and *fliC/flkA/flmA* alleles corresponding to O and H antigens, respectively. 
+This tool identifies the serotype of Escherichia coli genome sequences based on a set of *wzm/wzt*, *wzx/wzy* and *fliC/flkA/flmA* alleles corresponding to O and H antigens, respectively. 
 
 For more information please visit https://github.com/phac-nml/ecoli_serotyping. 
 
@@ -75,8 +83,9 @@ For more information please visit https://github.com/phac-nml/ecoli_serotyping.
 
 **Input:**
 
-Accepts a variety of inputs including single or multiple FASTQ and/or FASTA file(s). Inputs might contain pure raw reads, but for more accurate results draft assemblies are recommended.
+Accepts a variety of inputs including single or multiple FASTQ and/or FASTA file(s). Inputs might contain pure raw reads, but for more accurate results draft assemblies are recommended. 
 
+Optionally select a MASH RefSeq genome sketch (version 2.0 and above) for cases when O/H typing would fail. Download RefSeq genome sketch containing 91,283 genomes with 1000 hashes each directly from https://gembox.cbcb.umd.edu/mash/refseq.genomes.k21s1000.msh . 
 
 **Output:**
 
@@ -86,7 +95,7 @@ Tab-delimited report listing identified O and H antigens together with correspon
 
 **Parameters (Optional):**
 
-  - **Print the allele sequences as the final columns of the output?** Turn ON/OFF addition of the actual O and H antigen corresponding allelic sequences in the report
+  - **Print the allele sequences as the final columns of the output?** Turn ON/OFF addition of the actual O and H antigen allelic sequences in the report
   - **Enable E. coli species verification:** Turn ON/OFF for more rigorous species verification (recommended)
   - **Include log file in the run outputs?:** Turn ON/OFF optional output of the ectyper log file for a more detailed results assessment
 


### PR DESCRIPTION
Very minor change to the previous wrapper. Now incorporating ability to run mash distance calculations on the genomes that could not be typed using the O and H alleles.