### PR TITLE
Compatibility with Mykrobe Predictor 0.6.1

### DIFF
--- a/tools/mykrobe_parser/mykrobe_parser.R
+++ b/tools/mykrobe_parser/mykrobe_parser.R
@@ -152,7 +152,7 @@ params <- c("",  # Lims_Comment
             opt$depth,  # Mykrobe_min_depth_default_5
             opt$conf,  # Mykrobe_min_conf_default_10
             "",                             # LIMS_file - empty as it's an upload field in LIMS
-            opt$name)  # LIMS_filename
+            opt$name)  # Mutation_set_version
 
 names(params) <- c("Lims_Comment", 
                    "Lims_INTComment",
@@ -160,7 +160,7 @@ names(params) <- c("Lims_Comment",
                    "Mykrobe_min_depth_default_5",
                    "Mykrobe_min_conf_default_10", 
                    "LIMS_file", 
-                   "LIMS_filename")
+                   "Mutation_set_version")
 
 
 # A default report in the order our LIMS requires
@@ -185,9 +185,12 @@ columns <- c("file",
              "Mykrobe_rpsA",
              "Pyrazinamide_R_mutations",
              "Pyrazinamide_Prediction",
-             "Mykrobe_gyrA",
-             "Quinolones_R_mutations",
-             "Quinolones_Prediction",
+             "Mykrobe_Ofloxacin_gyrA",
+             "Ofloxacin_R_mutations",
+             "Ofloxacin_Prediction",
+             "Mykrobe_Moxifloxacin_gyrA",
+             "Moxifloxacin_R_mutations",
+             "Moxifloxacin_Prediction",
              "Mykrobe_rpsL",
              "Mykrobe_Streptomycin_rrs",
              "Mykrobe_Streptomycin_gid",
@@ -212,7 +215,7 @@ columns <- c("file",
              "Mykrobe_min_depth_default_5",
              "Mykrobe_min_conf_default_10",
              "LIMS_file",
-             "LIMS_filename")
+             "Mutation_set_version")
 
 report <- setNames(data.frame(matrix("", ncol = length(columns), nrow = 1), stringsAsFactors = F), columns)
 
@@ -222,7 +225,8 @@ all_drugs <- c("Isoniazid",
                "Rifampicin", 
                "Ethambutol", 
                "Pyrazinamide", 
-               "Moxifloxacin_Ofloxacin", 
+               "Moxifloxacin",
+               "Ofloxacin", 
                "Streptomycin",
                "Amikacin",
                "Capreomycin",
@@ -287,7 +291,7 @@ if (0 < predictions.table %>%
         mutate(variants = strsplit(variants, "__")) %>% # Split the mutations across rows (list first then split across rows)
         unnest(variants) %>% 
         separate(variants, c("gene", "mutation"), "_") %>% 
-        mutate(columnname = ifelse(gene %in% c("tlyA", "rrs", "gid"), # Check for columns that include the drug name or not and paste accordingly
+        mutate(columnname = ifelse(gene %in% c("tlyA", "rrs", "eis", "gid"), # Check for columns that include the drug name or not and paste accordingly
                                    paste("Mykrobe", drug, gene, sep = "_"),
                                    paste("Mykrobe", gene, sep = "_"))) %>% 
         # Extract out the mutation information with a regex that covers all potential genes
@@ -332,9 +336,7 @@ report <-
   filter_at(vars(ends_with("_Prediction")), any_vars(. != "failed")) %>% 
   mutate_at(vars(starts_with("Mykrobe_")), funs(replace(., is.na(.), "No Mutation"))) %>% 
   full_join(anti_join(report, ., by = "file")) %>% 
-  select(columns) %>% 
-  rename(Moxifloxacin_Ofloxacin_R_mutations = Quinolones_R_mutations,
-         Moxifloxacin_Ofloxacin_Prediction = Quinolones_Prediction)
+  select(columns) 
   
 
 # Add in the parameters fed from Galaxy using named character vector
@@ -347,7 +349,7 @@ report <-
     Mykrobe_min_depth_default_5 = params["Mykrobe_min_depth_default_5"],
     Mykrobe_min_conf_default_10 = params["Mykrobe_min_conf_default_10"],
     LIMS_file = params["LIMS_file"],
-    LIMS_filename = params["LIMS_filename"]
+    Mutation_set_version = params["Mutation_set_version"]
   )
   
 

--- a/tools/mykrobe_parser/mykrobe_parser.xml
+++ b/tools/mykrobe_parser/mykrobe_parser.xml
@@ -1,4 +1,4 @@
-<tool id="mykrobe_parseR" name="mykrobe_parseR" version="0.1.3">
+<tool id="mykrobe_parseR" name="mykrobe_parseR" version="0.1.4">
     <requirements>
         <requirement type="package" version="3.4.1">r-base</requirement>
         <requirement type="package" version="1.5.0">r-jsonlite</requirement>


### PR DESCRIPTION
- Fixed eis not being placed into Mykrobe_Kanamycin_eis
- Split Moxifloxacin and Ofloxacin into separate drug and mutation columns
- Renamed LIMS_Filename to Mutation_set_version for LIMS compatibility
- tested in R