### PR TITLE
All file extensions changed to .fasta for input fasta datasets.

### DIFF
--- a/tools/refseq_masher/.shed.yml
+++ b/tools/refseq_masher/.shed.yml
@@ -1,5 +1,7 @@
 categories: ["Sequence Analysis"]
-description: Find what NCBI RefSeq genomes match or are contained within your sequence data using Mash_ with a Mash sketch database of 54,925 NCBI RefSeq Genomes.
+description: Find what genomes match or are contained within your sequence data using Mash_ and a Mash sketch database.
 name: refseq_masher
 owner: nml
+long_description: Find the closest NCBI RefSeq genomes that either match or are contained within your sequence data using Mash_ with a Mash sketch database of 54,925 NCBI RefSeq Genomes.
+remote_repository_url: https://github.com/phac-nml/refseq_masher
 homepage_url: https://github.com/phac-nml/refseq_masher

--- a/tools/refseq_masher/contains.xml
+++ b/tools/refseq_masher/contains.xml
@@ -1,4 +1,4 @@
-<tool id="refseq_masher_contains" name="RefSeq Masher Contains" version="0.1.1">
+<tool id="refseq_masher_contains" name="RefSeq Masher Contains" version="0.1.2">
   <description>
     Find NCBI RefSeq Genomes contained in your sequences
   </description>
@@ -9,9 +9,10 @@
 <![CDATA[
 
 #import re
+#import os
 
 #if $input.type == 'fasta'
-#set $input_files = '"{}"'.format($input.fasta.name)
+#set $input_files = '"{}.fasta"'.format(os.path.splitext($input.fasta.name)[0])
   ln -s "$input.fasta" $input_files &&
 #elif $input.type == 'paired'
 #set $_forward_ext = '.fastq.gz' if $re.match(r'.*\.gz$', $input.forward.name) else '.fastq'

--- a/tools/refseq_masher/matches.xml
+++ b/tools/refseq_masher/matches.xml
@@ -1,4 +1,4 @@
-<tool id="refseq_masher_matches" name="RefSeq Masher Matches" version="0.1.1">
+<tool id="refseq_masher_matches" name="RefSeq Masher Matches" version="0.1.2">
   <description>
     Find closest matching NCBI RefSeq Genomes to your sequences
   </description>
@@ -9,9 +9,10 @@
 <![CDATA[
 
 #import re
+#import os
 
 #if $input.type == 'fasta'
-#set $input_files = '"{}"'.format($input.fasta.name)
+#set $input_files = '"{}.fasta"'.format(os.path.splitext($input.fasta.name)[0])
   ln -s "$input.fasta" $input_files &&
 #elif $input.type == 'paired'
 #set $_forward_ext = '.fastq.gz' if $re.match(r'.*\.gz$', $input.forward.name) else '.fastq'


### PR DESCRIPTION
Using OS, when the input data type is specified as fasta, the file extension will be removed and a .fasta will be appended onto the file.

This stops files from failing when they have a different extension (such as .txt) that was observed previously.