### PR TITLE
Staramr: strip slashes from input file names

### DIFF
--- a/tools/staramr/.shed.yml
+++ b/tools/staramr/.shed.yml
@@ -3,5 +3,5 @@ description: Scan genome contigs against the ResFinder, PlasmidFinder, and Point
 name: staramr
 owner: nml
 long_description: staramr - Scans genome contigs (in FASTA format) against the ResFinder, PlasmidFinder, and PointFinder databases to search for antimicrobial resistance genomes. Makes predictions of the drugs these genes give resistance to.
-remote_repository_url: https://github.com/phac-nml/staramr
+remote_repository_url: https://github.com/phac-nml/galaxy_tools/tree/master/tools/staramr
 homepage_url: https://github.com/phac-nml/staramr

--- a/tools/staramr/staramr_search.xml
+++ b/tools/staramr/staramr_search.xml
@@ -12,8 +12,8 @@
 
         #set $named_genomes = ''
         #for $genome in $genomes
-            #set $_named_genome = re.sub(r'(\s|\(|\))', '_', '"{}.fasta"'.format($genome.element_identifier))
-            ln -s "$genome" $_named_genome &&
+            #set $_named_genome = re.sub(r'(\s|\(|\)|\/)', '_', '"{}.fasta"'.format($genome.element_identifier))
+            ln -s '$genome' $_named_genome &&
             #set $named_genomes = $named_genomes + ' ' + $_named_genome
         #end for
 
@@ -353,7 +353,7 @@ The command-line, database versions, and other settings used to run `staramr`.
     plasmidfinder_db_commit       = 81919954cbedaff39056610ab584ab4c06011ed8
     plasmidfinder_db_date         = Tue, 20 Nov 2018 08:51
     pointfinder_gene_drug_version = 050218
-    resfinder_gene_drug_version   = 050218.1 
+    resfinder_gene_drug_version   = 050218.1
 
 results.xlsx
 ````````````
@@ -363,7 +363,7 @@ An Excel spreadsheet containing the previous 5 files as separate worksheets.
 BLAST Hits
 ``````````
 
-The dataset collection  **hits** stores fasta files of the specific blast hits. 
+The dataset collection  **hits** stores fasta files of the specific blast hits.
 
 Galaxy wrapper written by Aaron Petkau at the National Microbiology Laboratory, Public Health Agency of Canada.
 


### PR DESCRIPTION
When uploading files by URL into a collection, element identifiers will be the full URL, and cause a problem in the symlinking step, this adds forward slash to the set of sanitized characters

ping @apetkau 