### PR TITLE
Update mob_suite to v1.4.9.1

### DIFF
--- a/tools/mob_suite/mob_recon.xml
+++ b/tools/mob_suite/mob_recon.xml
@@ -1,7 +1,7 @@
-<tool id="mob_recon" name="MOB-Recon" version="1.4.8">
+<tool id="mob_recon" name="MOB-Recon" version="1.4.9.1+galaxy0">
   <description>Type contigs and extract plasmid sequences</description>
   <requirements>
-     <requirement type="package" version="1.4.8">mob_suite</requirement>
+     <requirement type="package" version="1.4.9.1">mob_suite</requirement>
   </requirements>   
   <command detect_errors="exit_code">
   <![CDATA[  

--- a/tools/mob_suite/mob_typer.xml
+++ b/tools/mob_suite/mob_typer.xml
@@ -1,7 +1,7 @@
-<tool id="mob_typer" name="MOB-Typer" version="1.4.8">
+<tool id="mob_typer" name="MOB-Typer" version="1.4.9.1+galaxy0">
   <description>Get the plasmid type and mobility given its sequence</description>
   <requirements>
-     <requirement type="package" version="1.4.8">mob_suite</requirement>
+     <requirement type="package" version="1.4.9.1">mob_suite</requirement>
   </requirements>   
   <command detect_errors="exit_code">
   <![CDATA[


### PR DESCRIPTION
I'd like to use a more recent version of mob_suite in an [IRIDA pipeline](https://github.com/dfornika/irida-plugin-plasmid-screen) that I'm developing.

Rather than go straight from `1.4.8` to `2.0.2` I thought it might make sense to update incrementally, so I'll submit a few PRs so that each version can be made available on the Galaxy toolshed.