### PR TITLE
Fix/update samtools in smalt environment

### DIFF
--- a/tools/smalt/smalt_map.xml
+++ b/tools/smalt/smalt_map.xml
@@ -6,7 +6,7 @@
     </macros>
     <requirements>
       <requirement type="package" version="@VERSION@">smalt</requirement>
-      <requirement type="package" version="1.5">samtools</requirement>
+      <requirement type="package" version="1.10">samtools</requirement>
     </requirements>
     <stdio>
         <exit_code range="1:"   level="fatal"   description="Unknown error" />

--- a/tools/smalt/smalt_map.xml
+++ b/tools/smalt/smalt_map.xml
@@ -1,4 +1,4 @@
-<tool id="smalt" name="smalt" version="@VERSION@+galaxy0">
+<tool id="smalt" name="smalt" version="@VERSION@+galaxy1">
     <description>Map query reads (FASTA/FASTQ) format onto the reference sequences</description>
     <macros>
       <token name="@VERSION@">0.7.6</token>


### PR DESCRIPTION
This updates the version of **samtools** installed alongside **smalt** from `1.5` to `1.10` (latest).

The reason is that version `1.5` is linked to the `libcrypto.so.1.0.0` library, which is not installed in the conda environment. This all still works in Ubuntu since `libcrypto.so.1.0.0` is available system-wide:

```
ldd `which samtools`|grep libcrypto
        libcrypto.so.1.0.0 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007f8fea892000)
```

But, on CentOS, this library is not available system-wide and so samtools crashes in Galaxy with:

```
samtools: error while loading shared libraries: libcrypto.so.1.0.0: cannot open shared object file: No such file or directory
```

However, **samtools** version `1.10` is not linked to `libcrypto.so.1.0.0` (it's not linked to libcrypto at all). Hence, there is no issues when running on CentOS or any other system.