### PR TITLE
Updating MOB-Suite to version 3.0.1 

### DIFF
--- a/tools/mob_suite/macros.xml
+++ b/tools/mob_suite/macros.xml
@@ -1,9 +1,8 @@
 <macros>
   <token name="@VERSION@">3.0.1</token>
-  
-  <xml name="requirements"> 
-  	<requirements>
-     		<requirement type="package" version ="@VERSION@">mob_suite</requirement>
-  	</requirements>
+  <xml name="requirements">
+  <requirements>
+  <requirement type="package" version ="@VERSION@">mob_suite</requirement>
+  </requirements>
   </xml>
 </macros>

--- a/tools/mob_suite/macros.xml
+++ b/tools/mob_suite/macros.xml
@@ -1,0 +1,9 @@
+<macros>
+  <token name="@VERSION@">3.0.1</token>
+  
+  <xml name="requirements"> 
+  	<requirements>
+     		<requirement type="package" version ="@VERSION@">mob_suite</requirement>
+  	</requirements>
+  </xml>
+</macros>

--- a/tools/mob_suite/mob_recon.xml
+++ b/tools/mob_suite/mob_recon.xml
@@ -1,7 +1,10 @@
-<tool id="mob_recon" name="MOB-Recon" version="3.0.0">
+<tool id="mob_recon" name="MOB-Recon" version="@VERSION@+galaxy0">
   <description>Type contigs and extract plasmid sequences</description>
+  <macros>
+   <token name="@VERSION@">3.0.1</token>
+  </macros>
   <requirements>
-     <requirement type="package" version="3.0.0">mob_suite</requirement>
+     <requirement type="package" version ="@VERSION@">mob_suite</requirement>
   </requirements>
   <version_command>mob_recon --version</version_command>
   <command detect_errors="exit_code">

--- a/tools/mob_suite/mob_recon.xml
+++ b/tools/mob_suite/mob_recon.xml
@@ -3,6 +3,7 @@
   <macros>
     <import>macros.xml</import>
   </macros>  
+  <expand macro="requirements" />
   <version_command>mob_recon --version</version_command>
   <command detect_errors="exit_code">
   <![CDATA[  

--- a/tools/mob_suite/mob_recon.xml
+++ b/tools/mob_suite/mob_recon.xml
@@ -1,11 +1,8 @@
 <tool id="mob_recon" name="MOB-Recon" version="@VERSION@+galaxy0">
   <description>Type contigs and extract plasmid sequences</description>
   <macros>
-   <token name="@VERSION@">3.0.1</token>
-  </macros>
-  <requirements>
-     <requirement type="package" version ="@VERSION@">mob_suite</requirement>
-  </requirements>
+    <import>macros.xml</import>
+  </macros>  
   <version_command>mob_recon --version</version_command>
   <command detect_errors="exit_code">
   <![CDATA[  

--- a/tools/mob_suite/mob_typer.xml
+++ b/tools/mob_suite/mob_typer.xml
@@ -4,7 +4,7 @@
    <token name="@VERSION@">3.0.1</token>
   </macros>
   <requirements>
-     <requirement type="package" version ="@VERSION@">mob_suite</requirement>
+     <requirement type="package" version = "@VERSION@">mob_suite</requirement>
   </requirements>
   <version_command>mob_typer --version</version_command>
   <command detect_errors="exit_code">

--- a/tools/mob_suite/mob_typer.xml
+++ b/tools/mob_suite/mob_typer.xml
@@ -1,7 +1,10 @@
-<tool id="mob_typer" name="MOB-Typer" version="3.0.0">
+<tool id="mob_typer" name="MOB-Typer" version="@VERSION@+galaxy0">
   <description>Get the plasmid type and mobility given its sequence</description>
+  <macros>
+   <token name="@VERSION@">3.0.1</token>
+  </macros>
   <requirements>
-     <requirement type="package" version="3.0.0">mob_suite</requirement>
+     <requirement type="package" version ="@VERSION@">mob_suite</requirement>
   </requirements>
   <version_command>mob_typer --version</version_command>
   <command detect_errors="exit_code">

--- a/tools/mob_suite/mob_typer.xml
+++ b/tools/mob_suite/mob_typer.xml
@@ -1,11 +1,9 @@
 <tool id="mob_typer" name="MOB-Typer" version="@VERSION@+galaxy0">
   <description>Get the plasmid type and mobility given its sequence</description>
   <macros>
-   <token name="@VERSION@">3.0.1</token>
+    <import>macros.xml</import>
   </macros>
-  <requirements>
-     <requirement type="package" version = "@VERSION@">mob_suite</requirement>
-  </requirements>
+  <expand macro="requirements"/>
   <version_command>mob_typer --version</version_command>
   <command detect_errors="exit_code">
   <![CDATA[


### PR DESCRIPTION
This wrapper is for MOB-Suite v3.0.1 addressing `pandas` and `ete3` libraries issues. This wrapper would make MOB-Suite v3.0.1 available on Galaxy. Previous Galaxy versions might encounter installation issues due to no restriction on pandas upper version limits. Manual roll back to `pandas` version <= 1.0.5 might be required. We hope this MOB-Suite version will solve once an forever any dependency issues.