### PR TITLE
Update staramr to 0.7.2

### DIFF
--- a/tools/staramr/staramr_search.xml
+++ b/tools/staramr/staramr_search.xml
@@ -1,7 +1,7 @@
-<tool id="staramr_search" name="staramr" version="@VERSION@+galaxy2">
+<tool id="staramr_search" name="staramr" version="@VERSION@+galaxy0">
     <description>Scans genome assemblies against the ResFinder, PlasmidFinder, and PointFinder databases searching for AMR genes.</description>
     <macros>
-        <token name="@VERSION@">0.7.1</token>
+        <token name="@VERSION@">0.7.2</token>
     </macros>
     <requirements>
         <requirement type="package" version="@VERSION@">staramr</requirement>


### PR DESCRIPTION
This updates the Galaxy tool version of starmar to `0.7.2` which is the latest in bioconda.

Version 0.7.2 fixed one small issue in staramr so that newer versions of pandas can be used (https://github.com/phac-nml/staramr/releases/tag/0.7.2).