### PR TITLE
Update SISTR to version 1.1.1+galaxy1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
       addons: {}
       before_install: skip
       install:
-        - pip install flake8 flake8-import-order planemo
+        - pip install flake8 flake8-import-order planemo==0.70.0
         - planemo --version
         - git diff --quiet "$TRAVIS_COMMIT_RANGE" -- ; GIT_DIFF_EXIT_CODE=$?
         - |

--- a/tools/sistr_cmd/README.md
+++ b/tools/sistr_cmd/README.md
@@ -2,10 +2,9 @@
 
 `SISTR` is a standalone serotyping module for *Salmonella* typing. The tool supports assembled genomes. 
 
-This Galaxy wrapper makes this tool accessible via Galaxy Project server and allows integration into workflows. Galaxy workflows include assembly and reporting steps for large sample sizes and are available to be installed from the main repository at [https://github.com/phac-nml/sistr_cmd](https://github.com/phac-nml/sistr_cmd)
+This Galaxy wrapper makes this tool accessible via Galaxy Project server and allows integration into workflows. Galaxy workflows include assembly and reporting steps for large sample sizes and are available to be installed from the main repository at <https://github.com/phac-nml/sistr_cmd>
 
-The tool can also be accessed via public instance at Galaxy EU at [https://usegalaxy.eu/root?tool_id=sistr_cmd](https://usegalaxy.eu/root?tool_id=sistr_cmd)
-
+The tool can also be accessed via public instance at Galaxy EU at <https://usegalaxy.eu/root?tool_id=sistr_cmd>
 
 # Citation
 If you find this tool useful, please cite as

--- a/tools/sistr_cmd/README.md
+++ b/tools/sistr_cmd/README.md
@@ -1,0 +1,13 @@
+# SISTR - Salmonella In Silico Typing Resource (SISTR) commandline tool
+
+`SISTR` is a standalone serotyping module for *Salmonella* typing. The tool supports assembled genomes. 
+
+This Galaxy wrapper makes this tool accessible via Galaxy Project server and allows integration into workflows. Galaxy workflows include assembly and reporting steps for large sample sizes and are available to be installed from the main repository at [https://github.com/phac-nml/sistr_cmd](https://github.com/phac-nml/sistr_cmd)
+
+The tool can also be accessed via public instance at Galaxy EU at [https://usegalaxy.eu/root?tool_id=sistr_cmd](https://usegalaxy.eu/root?tool_id=sistr_cmd)
+
+
+# Citation
+If you find this tool useful, please cite as
+
+><cite> The *Salmonella In Silico* Typing Resource (SISTR): an open web-accessible tool for rapidly typing and subtyping draft *Salmonella* genome assemblies. Catherine Yoshida, Peter Kruczkiewicz, Chad R. Laing, Erika J. Lingohr, Victor P.J. Gannon, John H.E. Nash, Eduardo N. Taboada. PLoS ONE 11(1): e0147101. doi: 10.1371/journal.pone.0147101 </cite>

--- a/tools/sistr_cmd/sistr_cmd.xml
+++ b/tools/sistr_cmd/sistr_cmd.xml
@@ -1,4 +1,4 @@
-<tool id="sistr_cmd" name="sistr_cmd" version="@VERSION@+galaxy0">
+<tool id="sistr_cmd" name="sistr_cmd" version="@VERSION@+galaxy1">
   <description>
     Salmonella In Silico Typing Resource commandline tool for serovar prediction 
   </description>

--- a/tools/sistr_cmd/sistr_cmd.xml
+++ b/tools/sistr_cmd/sistr_cmd.xml
@@ -1,4 +1,4 @@
-<tool id="sistr_cmd" name="sistr_cmd" version="@VERSION@">
+<tool id="sistr_cmd" name="sistr_cmd" version="@VERSION@+galaxy0">
   <description>
     Salmonella In Silico Typing Resource commandline tool for serovar prediction 
   </description>
@@ -14,7 +14,7 @@
   <command><![CDATA[
   sistr 
     #for $fasta in $input_fastas
-      -i '$fasta' '${$fasta.name.replace("." + $fasta.ext, "")}'
+      -i '$fasta' '${$fasta.element_identifier.replace("." + $fasta.ext, "")}'
     #end for
     -f $output_format
     -o sistr-report.$output_format
@@ -39,7 +39,7 @@
       optional="false" 
       multiple="true"
       format="fasta"
-      />
+    />
     <param 
       name="output_format" 
       type="select" 


### PR DESCRIPTION
By testing SISTR in workflow context it was identified that sample names are not propagated throughout all workflow stages (assembly, serotyping, reporting) resulting in  inability to easily map samples back to their original inputs. I've made a very minor change by use of `element_identifier` field instead of `name` for genome names. This issue is discussed at [https://planemo.readthedocs.io/en/latest/writing_advanced.html?highlight=element_identifier#processing-identifiers](https://planemo.readthedocs.io/en/latest/writing_advanced.html?highlight=element_identifier#processing-identifiers)