### PR TITLE
Version bump to 3.0.3

### DIFF
--- a/tools/mob_suite/macros.xml
+++ b/tools/mob_suite/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@VERSION@">3.0.1</token>
+  <token name="@VERSION@">3.0.3</token>
   <xml name="requirements">
   <requirements>
   <requirement type="package" version ="@VERSION@">mob_suite</requirement>


### PR DESCRIPTION
Version bump to v3.0.3 to match new MOB-Suite version 3.0.3 allowing to be deployed on read-only file systems (otherwise no algorithm update compared to version 3.0.0)