### PR TITLE
Tests only run on PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,5 +1,10 @@
 name: Galaxy Tool Linting and Tests for push and PR
-on: [push, pull_request]
+on:
+  pull_request: # Run on all PRs
+  push:
+    branches: # Run on any push to development or master
+      - development
+      - master
 env:
   GALAXY_FORK: galaxyproject
   GALAXY_BRANCH: release_22.01


### PR DESCRIPTION
Fixes test suite so we don't run the same tests on both PRs and pushes to the same branch.

Double-testing (for PR and Push) can be observed for the staramr PR:

![image](https://user-images.githubusercontent.com/200517/173438271-0c4bb869-7c69-4887-b870-cd94898f56a9.png)
