### PR TITLE
Add bio.tools for Cryptogenotyper

### DIFF
--- a/tools/cryptogenotyper/.shed.yml
+++ b/tools/cryptogenotyper/.shed.yml
@@ -3,5 +3,5 @@ description: CryptoGenotyper is a standalone tool to *in-silico*  determine spec
 name: cryptogenotyper
 owner: nml
 long_description: The CryptoGenotyper is a fast and reproducible tool that can be used to classify the genotype of Cryptosporidium samples by directly analyzing the DNA electropherogram files (.ab1) that correspond to two of its characteristic gene markers (SSU rRNA and gp60)
-remote_repository_url: https://github.com/phac-nml/CryptoGenotyper
+remote_repository_url: https://github.com/phac-nml/galaxy_tools/tree/master/tools/cryptogenotyper
 homepage_url: https://github.com/phac-nml/CryptoGenotyper

--- a/tools/cryptogenotyper/cryptogenotyper.xml
+++ b/tools/cryptogenotyper/cryptogenotyper.xml
@@ -5,6 +5,9 @@
   <macros>
    <token name="@VERSION@">1.0</token>
   </macros>
+  <xrefs>
+    <xref type="bio.tools">cryptogenotyper</xref>
+  </xrefs>
   <requirements>
     <requirement type="package" version ="@VERSION@">cryptogenotyper</requirement>
   </requirements>


### PR DESCRIPTION
Hi all,

This PR links the tools to its bio.tools entry: https://bio.tools/cryptogenotyper
It will be useful to get EDAM ontology annotations

Bérénice
