### PR TITLE
Add  bio.tools for MrBayes

### DIFF
--- a/tools/mrbayes/.shed.yml
+++ b/tools/mrbayes/.shed.yml
@@ -2,3 +2,5 @@ categories: [Sequence Analysis]
 description: A program for the Bayesian estimation of phylogeny.
 name: mrbayes
 owner: nml
+remote_repository_url: https://github.com/phac-nml/galaxy_tools/tree/master/tools/mrbayes
+homepage_url: http://nbisweden.github.io/MrBayes/

--- a/tools/mrbayes/mrbayes.xml
+++ b/tools/mrbayes/mrbayes.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <tool id="mrbayes" name="MrBayes" version="1.0.2">
     <description>with options and commands</description>
+    <xrefs>
+        <xref type="bio.tools">mrbayes</xref>
+    </xrefs>
     <requirements>
         <requirement type="package" version="3.2.6">mrbayes</requirement>
     </requirements>


### PR DESCRIPTION
Hi all,

This PR links the tools to its bio.tools entry: https://bio.tools/mrbayes
It will be useful to get EDAM ontology annotations

Bérénice
