### PR TITLE
Update assembly_stats_txt.xml

### DIFF
--- a/tools/assemblystats/assembly_stats_txt.xml
+++ b/tools/assemblystats/assembly_stats_txt.xml
@@ -1,5 +1,8 @@
 <tool id="assemblystats" name="assemblystats" version="1.1.0">
 	<description>Summarise an assembly (e.g. N50 metrics)</description>
+	<xrefs>
+    		<xref type="bio.tools">assemblystats</xref>
+	</xrefs>
 	<requirements>
 		<requirement type="package" version="1.7.2">perl-bioperl</requirement>
 		<requirement type="package" version="5.2.7">gnuplot</requirement>


### PR DESCRIPTION
This is a great tool !
In order to improve the EDAM based annotation of this tool the bio.tools xref [assemblystats](https://bio.tools/assemblystats) is added.
Please also review the bio.tools entry and check if the assigned EDAM term and annotations are correct.