### PR TITLE
Add bio.tools for plasmidspades

### DIFF
--- a/tools/plasmidspades/.shed.yml
+++ b/tools/plasmidspades/.shed.yml
@@ -2,3 +2,4 @@ categories: [Assembly]
 description: Genome assembler for assemblying plasmid
 name: plasmidspades
 owner: nml
+remote_repository_url: https://github.com/phac-nml/galaxy_tools/tree/master/tools/plasmidspades

--- a/tools/plasmidspades/plasmidSPAdes.xml
+++ b/tools/plasmidspades/plasmidSPAdes.xml
@@ -1,5 +1,8 @@
 <tool id="plasmidspades" name="plasmidspades" version="1.1">
   <description>genome assembler for plasmids</description>
+  <xrefs>
+    <xref type="bio.tools">plasmidspades</xref>
+  </xrefs>
   <requirements>
     <requirement type="package" version="3.9.0">spades</requirement>
   </requirements>


### PR DESCRIPTION
Hi all,

This PR links the tools to its bio.tools entry: https://bio.tools/plasmidspades
It will be useful to get EDAM ontology annotations

Engy
