### PR TITLE
Add bio.tools ref to staramr

### DIFF
--- a/tools/staramr/staramr_search.xml
+++ b/tools/staramr/staramr_search.xml
@@ -3,6 +3,9 @@
     <macros>
         <token name="@VERSION@">0.10.0</token>
     </macros>
+    <xrefs>
+        <xref type="bio.tools">staramr</xref>
+    </xrefs>
     <requirements>
         <requirement type="package" version="@VERSION@">staramr</requirement>
 	<!-- The staramr conda package includes the mlst software, but the list of schemes 


### PR DESCRIPTION
This PR links staramr to its bio.tools [entry](https://bio.tools/staramr).