### PR TITLE
Add bio.tools ref to srst2

### DIFF
--- a/tools/srst2/srst2.xml
+++ b/tools/srst2/srst2.xml
@@ -1,5 +1,8 @@
 <tool id="srst2" name="SRST2" version="0.3.7">
     <description>Short Read Sequence Typing for Bacterial Pathogens</description>
+    <xrefs>
+        <xref type="bio.tools">srst2</xref>
+    </xrefs>
     <requirements>
         <requirement type="package" version="0.1.4.6">srst2</requirement>
         <requirement type="package" version="08-07-2014">vfdb</requirement>


### PR DESCRIPTION
This PR links srst2 to its bio.tools [entry](https://bio.tools/srst2).