### PR TITLE
fixed optional rendering of the plasmid report in MOB-Typer with this new small patch

### DIFF
--- a/tools/mob_suite/mob_recon.xml
+++ b/tools/mob_suite/mob_recon.xml
@@ -138,7 +138,7 @@
     </collection>
   </outputs>
   <tests>
-    <test>
+    <test expect_num_outputs=4>
       <param name="input" value="Ecoli_strain_KV7_complete_LT795502.fasta" ftype="fasta"/>
       <section name="adv_param">
         <param name="unicycler_contigs" value="True"/>

--- a/tools/mob_suite/mob_recon.xml
+++ b/tools/mob_suite/mob_recon.xml
@@ -138,7 +138,7 @@
     </collection>
   </outputs>
   <tests>
-    <test expect_num_outputs=4>
+    <test expect_num_outputs="2">
       <param name="input" value="Ecoli_strain_KV7_complete_LT795502.fasta" ftype="fasta"/>
       <section name="adv_param">
         <param name="unicycler_contigs" value="True"/>

--- a/tools/mob_suite/mob_recon.xml
+++ b/tools/mob_suite/mob_recon.xml
@@ -138,7 +138,7 @@
     </collection>
   </outputs>
   <tests>
-    <test expect_num_outputs="2">
+    <test expect_num_outputs="4">
       <param name="input" value="Ecoli_strain_KV7_complete_LT795502.fasta" ftype="fasta"/>
       <section name="adv_param">
         <param name="unicycler_contigs" value="True"/>

--- a/tools/mob_suite/mob_typer.xml
+++ b/tools/mob_suite/mob_typer.xml
@@ -1,4 +1,4 @@
-<tool id="mob_typer" name="MOB-Typer" version="@VERSION@+galaxy0">
+<tool id="mob_typer" name="MOB-Typer" version="@VERSION@+galaxy1">
   <description>Get the plasmid type and mobility given its sequence</description>
   <macros>
     <import>macros.xml</import>
@@ -65,8 +65,7 @@
    #if $adv_param.biomarker_report_file
    --biomarker_report_file biomarker_report.txt
    #end if
-   
-
+  
    --out_file plasmid_report.txt;
 
   ]]>
@@ -74,9 +73,8 @@
   <inputs>
     <param name="input" type="data" format="fasta" label="Input" help="FASTA file with contig(s)"/>
     <section name="adv_param" title="Advanced parameters" expanded="False">
-      <param name="multi" type="boolean" truevalue="true" falsevalue="" checked="false" label="Treat each input sequence as an independent plasmid?" help="Treat each sequence in the FASTA file as a separate input (--multi)" />
-      <param name="biomarker_report_file" type="boolean" truevalue="true" falsevalue="" checked="false" label="Output BLAST biomarker report?" help="The report will report all biomarkers identified in a given query plasmid (--biomarker_report_file)" />
-
+      <param name="multi" type="boolean"  checked="false" label="Treat each input sequence as an independent plasmid?" help="Treat each sequence in the FASTA file as a separate input (--multi)" />
+      <param name="biomarker_report_file" type="boolean" checked="true" label="Output BLAST biomarker report?" help="The report will report all biomarkers identified in a given query plasmid (--biomarker_report_file)" />
       <param name="min_rep_evalue_value" type="float" value="0.00001" min="0.00001" max="1" label="Minimum evalue threshold for replicon blastn" help="(--min_rep_evalue)"/> 
       <param name="min_mob_evalue_value" type="float" value="0.00001" min="0.00001" max="1" label="Minimum evalue threshold for relaxase tblastn" help="(--min_mob_evalue)"/> 
       <param name="min_con_evalue_value" type="float" value="0.00001" min="0.00001" max="1" label="Minimum evalue threshold for contig blastn" help="(--min_con_evalue)"/> 
@@ -101,7 +99,9 @@
   </inputs>
   <outputs>
     <data name="plasmid_report" from_work_dir="plasmid_report.txt" label="${tool.name}: Plasmid report on ${input.element_identifier}"  format="tabular" />
-    <data name="biomarker_report" from_work_dir="biomarker_report.txt" label="${tool.name}: Biomarker report on ${input.element_identifier}"  format="tabular" />
+    <data name="biomarker_report" from_work_dir="biomarker_report.txt" label="${tool.name}: Biomarker report on ${input.element_identifier}"  format="tabular">
+     <filter>adv_param["biomarker_report_file"]</filter> 
+    </data>
   </outputs>
   <tests>
     <test>

--- a/tools/mob_suite/mob_typer.xml
+++ b/tools/mob_suite/mob_typer.xml
@@ -104,7 +104,7 @@
     </data>
   </outputs>
   <tests>
-    <test expect_num_outputs="1">
+    <test expect_num_outputs="2">
       <param name="input" value="plasmid_476.fasta" ftype="fasta"/>
       <output name="plasmid_report">
         <assert_contents>

--- a/tools/mob_suite/mob_typer.xml
+++ b/tools/mob_suite/mob_typer.xml
@@ -104,7 +104,7 @@
     </data>
   </outputs>
   <tests>
-    <test>
+    <test expect_num_outputs=2>
       <param name="input" value="plasmid_476.fasta" ftype="fasta"/>
       <output name="plasmid_report">
         <assert_contents>

--- a/tools/mob_suite/mob_typer.xml
+++ b/tools/mob_suite/mob_typer.xml
@@ -104,7 +104,7 @@
     </data>
   </outputs>
   <tests>
-    <test expect_num_outputs=2>
+    <test expect_num_outputs="1">
       <param name="input" value="plasmid_476.fasta" ftype="fasta"/>
       <output name="plasmid_report">
         <assert_contents>


### PR DESCRIPTION
This small patch fixes the optional `biomarker report` output in `MOB-Typer` and makes it a default option. This makes the GUI more friendly and useful for the users. That is why I decided to make small update to the recipe after using it myself. The biomarker report output will only be displayed if such option is selected (which it is now by default). In recipe `galaxy0` this report appears always regardless of the selection which is a bug
