### PR TITLE
Update StarAMR to 0.12.3

### DIFF
--- a/tools/staramr/staramr_search.xml
+++ b/tools/staramr/staramr_search.xml
@@ -1,7 +1,7 @@
 <tool id="staramr_search" name="staramr" version="@VERSION@+galaxy0" profile="25.1">
     <description>Scans genome assemblies against the ResFinder, PlasmidFinder, and PointFinder databases searching for AMR genes.</description>
     <macros>
-        <token name="@VERSION@">0.12.2</token>
+        <token name="@VERSION@">0.12.3</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">staramr</xref>

--- a/tools/staramr/test-data/test1-detailed-summary.tsv
+++ b/tools/staramr/test-data/test1-detailed-summary.tsv
@@ -1,6 +1,6 @@
 Isolate ID	Data	Data Type	Predicted Phenotype	CGE Predicted Phenotype	%Identity	%Overlap	HSP Length/Total Length	Contig	Start	End	Accession
 16S-rc_gyrA-rc_beta-lactam.fsa	ST- (-)	MLST									
 16S-rc_gyrA-rc_beta-lactam.fsa	None	Plasmid									
-16S-rc_gyrA-rc_beta-lactam.fsa	16S_rrsD (C1065T)	Resistance	spectinomycin	Spectinomycin	99.935	100.0	1544/1544	16S_rrsD	1604	61	
+16S-rc_gyrA-rc_beta-lactam.fsa	16S_rrsD (C1065T)	Resistance	spectinomycin	Spectinomycin	99.94	100.0	1544/1544	16S_rrsD	1604	61	
 16S-rc_gyrA-rc_beta-lactam.fsa	blaIMP-42	Resistance	ampicillin, amoxicillin/clavulanic acid, cefoxitin, ceftriaxone, meropenem	Amoxicillin, Amoxicillin+Clavulanic acid, Ampicillin, Ampicillin+Clavulanic acid, Cefepime, Cefixime, Cefotaxime, Cefoxitin, Ceftazidime, Ertapenem, Imipenem, Meropenem, Piperacillin, Piperacillin+Tazobactam	99.73	100.0	741/741	16S_rrsD	4381	5121	AB753456
-16S-rc_gyrA-rc_beta-lactam.fsa	gyrA (A67P)	Resistance	ciprofloxacin I/R, nalidixic acid	Nalidixic acid,Ciprofloxacin	99.962	100.0	2637/2637	16S_rrsD	4317	1681	
+16S-rc_gyrA-rc_beta-lactam.fsa	gyrA (A67P)	Resistance	ciprofloxacin I/R, nalidixic acid	Nalidixic acid,Ciprofloxacin	99.96	100.0	2637/2637	16S_rrsD	4317	1681	


### PR DESCRIPTION
I manually ran these inputs through a local Galaxy instance to check the update:
- CmlA7_1_JQ639792.fasta -> chloramphenicol	Chloramphenicol (new CmlAs)
- FloR_4_CP136914.fasta -> chloramphenicol, florfenicol	Chloramphenicol,Florphenicol (new FloRs)
- floR_1_AF071555_modified -> 99.92	99.67 (round to 2 places)


```
Isolate ID	Data	Data Type	Predicted Phenotype	CGE Predicted Phenotype	%Identity	%Overlap	HSP Length/Total Length	Contig	Start	End	Accession
CmlA7_1_JQ639792.fasta	ST- (-)	MLST									
CmlA7_1_JQ639792.fasta	None	Plasmid									
CmlA7_1_JQ639792.fasta	CmlA7	Resistance	chloramphenicol	Chloramphenicol	100.0	100.0	1314/1314	CmlA7_1_JQ639792	1	1314	JQ639792
FloR_4_CP136914.fasta	ST- (-)	MLST									
FloR_4_CP136914.fasta	None	Plasmid									
FloR_4_CP136914.fasta	FloR	Resistance	chloramphenicol, florfenicol	Chloramphenicol,Florphenicol	100.0	100.0	1215/1215	FloR_4_CP136914	1	1215	CP136914
floR_1_AF071555_modified.fasta	ST- (-)	MLST									
floR_1_AF071555_modified.fasta	None	Plasmid									
floR_1_AF071555_modified.fasta	floR	Resistance	chloramphenicol, florfenicol	Chloramphenicol, Florfenicol	99.92	99.67	1211/1215	floR_1_AF071555_modified	1	1211	AF071555
```